### PR TITLE
Generate Gihub Pages with Github Actions 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,49 @@
+name: docs
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install dependencies
+        run: poetry install --with doc
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Build with mkdocs
+        working-directory: doc
+        run: poetry run mkdocs build -d site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./doc/site
+
+  deploy:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         run: poetry install --no-root --with doc
       - name: Build with mkdocs
         working-directory: doc
-        run: poetry run mkdocs build -d site
+        run: mkdir -p docs && poetry run mkdocs build -d site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,6 @@ jobs:
         run: pip install poetry
       - name: Install dependencies
         run: poetry install --no-root --with doc
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
       - name: Build with mkdocs
         working-directory: doc
         run: poetry run mkdocs build -d site

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         run: poetry install --no-root --with doc
       - name: Build with mkdocs
         working-directory: doc
-        run: mkdir -p docs && poetry run mkdocs build -d site
+        run: poetry run mkdocs build -d site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Poetry
         run: pip install poetry
       - name: Install dependencies
-        run: poetry install --with doc
+        run: poetry install --no-root --with doc
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,4 @@ coverage.xml
 poetry.lock
 
 # MkDoc generated docs
-doc/docs
 doc/site

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,10 @@ coverage.xml
 *.iws
 *.ipr
 *.iml
+
+# Poetry
+poetry.lock
+
+# MkDoc generated docs
+doc/docs
+doc/site

--- a/doc/docs/model/algorithm.md
+++ b/doc/docs/model/algorithm.md
@@ -1,0 +1,3 @@
+# Algorithm
+
+{algorithm_schema}

--- a/doc/docs/model/dataset.md
+++ b/doc/docs/model/dataset.md
@@ -1,0 +1,3 @@
+# Dataset
+
+{dataset_schema}

--- a/doc/docs/model/hardware.md
+++ b/doc/docs/model/hardware.md
@@ -1,0 +1,3 @@
+# Hardware
+
+{hardware_schema}

--- a/doc/docs/model/measure.md
+++ b/doc/docs/model/measure.md
@@ -1,0 +1,3 @@
+# Measure
+
+{measure_schema}

--- a/doc/docs/model/report.md
+++ b/doc/docs/model/report.md
@@ -1,0 +1,3 @@
+# Report
+
+{report_schema}

--- a/doc/gen_pages.py
+++ b/doc/gen_pages.py
@@ -1,0 +1,8 @@
+import mkdocs_gen_files
+
+with open("../README.md") as f:
+    content = f.read()
+    with mkdocs_gen_files.open("index.md", "w") as f:
+        f.write(content)
+
+    mkdocs_gen_files.set_edit_path("index.md", "../README.md")

--- a/doc/gen_pages.py
+++ b/doc/gen_pages.py
@@ -1,8 +1,14 @@
 import mkdocs_gen_files
+from pathlib import Path
 
 with open("../README.md") as f:
     content = f.read()
-    with mkdocs_gen_files.open("index.md", "w") as f:
-        f.write(content)
+with mkdocs_gen_files.open("index.md", "w") as f:
+    f.write(content)
 
-    mkdocs_gen_files.set_edit_path("index.md", "../README.md")
+mkdocs_gen_files.set_edit_path("index.md", "../README.md")
+
+for src in Path("../Resources").iterdir():
+    with open(src, "rb") as f_in:
+        with mkdocs_gen_files.open(f"Resources/{src.name}", "wb") as f_out:
+            f_out.write(f_in.read())

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,0 +1,39 @@
+site_name: BoAmps Documentation
+
+theme:
+  name: material
+
+plugins:
+  - search
+  - gen-files:
+      scripts:
+        - gen_pages.py
+  - json-schema:
+      json_schema: ../model/report_schema.json
+      markdown_tag: "{report_schema}"
+  - json-schema:
+      json_schema: ../model/hardware_schema.json
+      markdown_tag: "{hardware_schema}"
+  - json-schema:
+      json_schema: ../model/algorithm_schema.json
+      markdown_tag: "{algorithm_schema}"
+  - json-schema:
+      json_schema: ../model/dataset_schema.json
+      markdown_tag: "{dataset_schema}"
+  - json-schema:
+      json_schema: ../model/measure_schema.json
+      markdown_tag: "{measure_schema}"
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+
+nav:
+  - Home: index.md
+  - Model:
+    - Report: model/report.md
+    - Hardware: model/hardware.md
+    - Algorithm: model/algorithm.md
+    - Dataset: model/dataset.md
+    - Measure: model/measure.md

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: BoAmps Documentation
+site_url: https://bamthomas.github.io/BoAmps/
 
 theme:
   name: material

--- a/model/algorithm_schema.json
+++ b/model/algorithm_schema.json
@@ -58,8 +58,9 @@
         "description" : "the algorithm used to optimize the models weights, e.g. gridSearch, lora, adam"
       },
       "quantization":{
-        "type":"string", 
+        "type":"string",
         "description": "the type of quantization used : fp32, fp16, b16, int8 ... "
       }
-    }
+    },
+    "required": []
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ mkdocs = "^1.5.0"
 mkdocs-material = "^9.0.0"
 mkdocs-gen-files = "*"
 mkdocs-macros-plugin = "*"
-mkdocsjsonschemaplugin = "*"
+mkdocsjsonschemaplugin = {git = "git@github.com:bamthomas/mkdocs-json-schema-plugin.git"}
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "BoAmps"
+version = "0.0.1"
+description = "json ontology standard describing a power consumption measure in a given software/hardware context, noticeably in machine learning tasks. It also provides the tooling for conversion to tabular datasets. "
+authors = ["Boavizta <contact@boavizta.org>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.12"
+
+[tool.poetry.group.doc.dependencies]
+mkdocs = "^1.5.0"
+mkdocs-material = "^9.0.0"
+mkdocs-gen-files = "*"
+mkdocs-macros-plugin = "*"
+mkdocsjsonschemaplugin = "*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ mkdocs = "^1.5.0"
 mkdocs-material = "^9.0.0"
 mkdocs-gen-files = "*"
 mkdocs-macros-plugin = "*"
-mkdocsjsonschemaplugin = {git = "git@github.com:bamthomas/mkdocs-json-schema-plugin.git"}
+mkdocsjsonschemaplugin = {git = "https://github.com/bamthomas/mkdocs-json-schema-plugin.git"}
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR is for generating a GH pages web site with the models. 

It uses [mkdocs](https://www.mkdocs.org/) with a slightly updated [mkdocs-json-schema-plugin](https://github.com/galamdring/mkdocs-json-schema-plugin).

You can see what it's like on the forked repo : https://bamthomas.github.io/BoAmps/

The following changes have been made:

1. add a pyproject.toml to use python 
2. add doc/mkdocs.yml that is describing how to make the site to mkdocs
3. add doc/gen_pages.py that will reuse resources and README.md
4. add doc/docs/model templates files
5. finally add the github workflow to generate GH pages

If you merge it you will have to change 

```yaml
site_url: https://bamthomas.github.io/BoAmps/
```
in mkdocs.yml to `https://boavizta.github.io/boamps`

It is possible eventually to configure a more fancy url like https://boamps.boavizta.org.

TODO: there is a little bug in the model generated pages that are not folding/unfolding.